### PR TITLE
fix: today's transactions not shown due to UTC/local timezone mismatch

### DIFF
--- a/core/database/src/main/java/soft/divan/financemanager/core/database/dao/TransactionDao.kt
+++ b/core/database/src/main/java/soft/divan/financemanager/core/database/dao/TransactionDao.kt
@@ -18,7 +18,7 @@ interface TransactionDao {
         """
     SELECT * FROM transactions
     WHERE accountLocalId = :accountId
-      AND date(transactionDate) BETWEEN date(:startDate) AND date(:endDate)
+      AND date(transactionDate, 'localtime') BETWEEN date(:startDate) AND date(:endDate)
     ORDER BY transactionDate ASC
 """
     )


### PR DESCRIPTION
## Проблема

Транзакции за «сегодня» не отображались на экране transactions-today, хотя существовали; при выборе более широкого периода (история/анализ) они показывались.

## Причина

Транзакции хранятся в БД в **UTC** (`TimeMapper.toApi` → `...Z`), а границы периода считаются в **локальной** зоне (`ApiDateMapper` / `UiDateFormatter`, `ZoneId.systemDefault()`).

Запрос `TransactionDao.getByAccountAndPeriod` сравнивал:

```sql
date(transactionDate) BETWEEN date(:startDate) AND date(:endDate)
```

`date(transactionDate)` извлекает дату из UTC-строки **в UTC**, а границы — локальные даты. У границы суток дата транзакции в UTC может отличаться от локальной «сегодня» на ±1 день и выпадать из однодневного окна. В широком периоде сдвиг прячется внутри диапазона — поэтому ломалось именно «сегодня».

## Фикс

```sql
date(transactionDate, 'localtime') BETWEEN date(:startDate) AND date(:endDate)
```

Дата транзакции приводится к локальной зоне — обе стороны `BETWEEN` теперь в одной зоне. `'localtime'` корректно учитывает суффикс `Z` (проверено на SQLite). Правит сразу transactions-today, history и analysis — они ходят через один запрос. Схема БД не меняется, миграция не нужна.

🤖 Generated with [Claude Code](https://claude.com/claude-code)