### PR TITLE
test(network): fix AuthInterceptorTest for Provider<AuthManager> API (unblock CI)

### DIFF
--- a/core/network/src/test/java/soft/divan/financemanager/core/network/interceptor/AuthInterceptorTest.kt
+++ b/core/network/src/test/java/soft/divan/financemanager/core/network/interceptor/AuthInterceptorTest.kt
@@ -8,6 +8,8 @@ import okhttp3.Interceptor
 import okhttp3.Request
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import soft.divan.financemanager.core.auth.data.authenticator.AuthManager
+import javax.inject.Provider
 
 class AuthInterceptorTest {
 
@@ -22,10 +24,16 @@ class AuthInterceptorTest {
         return chain
     }
 
+    private fun interceptorWithToken(token: () -> String?): AuthInterceptor {
+        val authManager = mockk<AuthManager>()
+        every { authManager.getAccessToken() } answers { token() }
+        return AuthInterceptor(Provider { authManager })
+    }
+
     @Test
     fun `adds Authorization header with bearer token`() {
         val slot = slot<Request>()
-        val interceptor = AuthInterceptor { "my-token" }
+        val interceptor = interceptorWithToken { "my-token" }
 
         interceptor.intercept(chainReturning(slot))
 
@@ -35,7 +43,7 @@ class AuthInterceptorTest {
     @Test
     fun `keeps original url and method`() {
         val slot = slot<Request>()
-        val interceptor = AuthInterceptor { "t" }
+        val interceptor = interceptorWithToken { "t" }
 
         interceptor.intercept(chainReturning(slot))
 
@@ -47,7 +55,7 @@ class AuthInterceptorTest {
     fun `evaluates token lazily on each request`() {
         val slot = slot<Request>()
         var current = "first"
-        val interceptor = AuthInterceptor { current }
+        val interceptor = interceptorWithToken { current }
 
         interceptor.intercept(chainReturning(slot))
         assertThat(slot.captured.header("Authorization")).isEqualTo("Bearer first")
@@ -59,10 +67,20 @@ class AuthInterceptorTest {
     }
 
     @Test
+    fun `proceeds without Authorization header when token is null`() {
+        val slot = slot<Request>()
+        val interceptor = interceptorWithToken { null }
+
+        interceptor.intercept(chainReturning(slot))
+
+        assertThat(slot.captured.header("Authorization")).isNull()
+    }
+
+    @Test
     fun `proceeds with the modified request exactly once`() {
         val slot = slot<Request>()
         val chain = chainReturning(slot)
-        val interceptor = AuthInterceptor { "t" }
+        val interceptor = interceptorWithToken { "t" }
 
         interceptor.intercept(chain)
 


### PR DESCRIPTION
## Проблема

CI падал на `:core:network:compileDebugUnitTestKotlin`:

```
Return type mismatch: expected 'AuthManager!', actual 'String'.
  AuthInterceptorTest.kt:28, :38, :50, :65
```

Причина не связана с изменениями транзакций. Влитый auth-рефактор изменил конструктор `AuthInterceptor` с лямбды токена `() -> String` на `Provider<AuthManager>`, но тест `AuthInterceptorTest` остался от старой версии и создавал интерцептор через `AuthInterceptor { "my-token" }`. Лямбда трактовалась как `Provider<AuthManager>`, чей `get()` должен вернуть `AuthManager` — отсюда ошибка компиляции.

## Фикс

Переписал тест под новый API: мок `AuthManager` оборачивается в `Provider`. Поведение проверок сохранено (заголовок `Bearer`, url/метод, ленивое вычисление токена, ровно один `proceed`) и добавлен кейс на новую ветку с пустым/`null` токеном — заголовок `Authorization` не добавляется.

Локально: `./gradlew :core:network:testDebugUnitTest` — BUILD SUCCESSFUL, все тесты зелёные.